### PR TITLE
Timeline tags

### DIFF
--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -158,6 +158,8 @@ class GitConnector(Component):
                         tag_info = repo.git.repo.for_each_ref(*for_each_args)
                     for line in tag_info.splitlines():
                         (tag_name,tag_deref,user,tag_time_str,tag_msg) = line.split('|+')
+                        if not tag_time_str:
+                            continue  # probably a lightweight tag
 
                         # Parse time using Trac's parse_time (requires T and Z unfortunately)
                         date_str, time_str, tz_str = tag_time_str.rsplit(None, 2)


### PR DESCRIPTION
Implements ITimelineEventProvider to put Git tags on the Trac timeline.  I'm pretty happy with this implementation, but if you add the tag date to the rev_cache this could be accelerated somewhat (it would then only have to call the system if it needs tag metadata).

Thanks,
Stephen
