### PR TITLE
Repo provider and bug fix

### DIFF
--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -17,7 +17,8 @@ from trac.util import TracError, shorten_line
 from trac.util.datefmt import FixedOffset, to_timestamp, format_datetime
 from trac.util.text import to_unicode
 from trac.versioncontrol.api import \
-     Changeset, Node, Repository, IRepositoryConnector, NoSuchChangeset, NoSuchNode
+     Changeset, Node, Repository, IRepositoryConnector, NoSuchChangeset, NoSuchNode, \
+     IRepositoryProvider
 from trac.wiki import IWikiSyntaxProvider
 from trac.versioncontrol.cache import CachedRepository, CachedChangeset
 from trac.versioncontrol.web_ui import IPropertyRenderer
@@ -28,6 +29,7 @@ from genshi.builder import tag
 
 from datetime import datetime
 import sys
+import os
 
 if not sys.version_info[:2] >= (2, 5):
     raise TracError("Python >= 2.5 dependancy not met")
@@ -681,3 +683,29 @@ class GitChangeset(Changeset):
 
         return [ (k, v == _rev)
                  for k, v in self.repos.git.get_branch_contains(_rev, resolve=True) ]
+
+class GitwebProjectsRepositoryProvider(Component):
+    implements(IRepositoryProvider)
+
+    projects_list = PathOption('git', 'projects_list', 'Path to a gitweb-formatted projects.list')
+    projects_base = PathOption('git', 'projects_base', 'Path to the base of your git projects')
+    projects_url = Option('git', 'projects_url', 'Template for project URLs. %s will be replaced with the repo name')
+
+    def get_repositories(self):
+        if not self.projects_list:
+            return
+
+        for line in open(self.projects_list):
+            line = line.strip()
+            repo = {
+                'dir': os.path.join(self.projects_base, line),
+                'type': 'git',
+            }
+            description_path = os.path.join(repo['dir'], 'description')
+            if os.path.exists(description_path):
+                repo['description'] = open(description_path).read().strip()
+            if self.projects_url:
+                if line.endswith('.git'):
+                    line = line[:-4]
+                repo['url'] = self.projects_url % line
+            yield repo

--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -631,7 +631,7 @@ class GitChangeset(Changeset):
         Changeset.__init__(self, repos, rev=sha, message=msg, author=user_, date=time_)
 
     def __repr__(self):
-        return '<GitChangeset %r %s>'%(self.repos, self.rev)
+        return '<GitChangeset %s>'%(self.rev,)
 
     def get_properties(self):
         properties = {}

--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -369,6 +369,9 @@ class GitRepository(Repository):
 
         Repository.__init__(self, "git:"+path, self.params, log)
 
+    def __repr__(self):
+        return '<GitRepository %s %s>'%(self.gitrepo, self.params)
+
     def close(self):
         self.git = None
 
@@ -626,6 +629,9 @@ class GitChangeset(Changeset):
         user_ = repos.rlookup_uid(user_) or user_
 
         Changeset.__init__(self, repos, rev=sha, message=msg, author=user_, date=time_)
+
+    def __repr__(self):
+        return '<GitChangeset %r %s>'%(self.repos, self.rev)
 
     def get_properties(self):
         properties = {}

--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -602,6 +602,9 @@ class GitChangeset(Changeset):
         } # TODO: U, X, B
 
     def __init__(self, repos, sha):
+        if sha is None:
+            raise NoSuchChangeset(sha)
+        
         try:
             msg, props = repos.git.read_commit(sha)
         except PyGIT.GitErrorSha:

--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -697,6 +697,9 @@ class GitwebProjectsRepositoryProvider(Component):
 
         for line in open(self.projects_list):
             line = line.strip()
+            name = line
+            if name.endswith('.git'):
+                name = name[:-4]
             repo = {
                 'dir': os.path.join(self.projects_base, line),
                 'type': 'git',
@@ -705,7 +708,5 @@ class GitwebProjectsRepositoryProvider(Component):
             if os.path.exists(description_path):
                 repo['description'] = open(description_path).read().strip()
             if self.projects_url:
-                if line.endswith('.git'):
-                    line = line[:-4]
-                repo['url'] = self.projects_url % line
-            yield repo
+                repo['url'] = self.projects_url % name
+            yield name, repo

--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -687,9 +687,9 @@ class GitChangeset(Changeset):
 class GitwebProjectsRepositoryProvider(Component):
     implements(IRepositoryProvider)
 
-    projects_list = PathOption('git', 'projects_list', 'Path to a gitweb-formatted projects.list')
-    projects_base = PathOption('git', 'projects_base', 'Path to the base of your git projects')
-    projects_url = Option('git', 'projects_url', 'Template for project URLs. %s will be replaced with the repo name')
+    projects_list = PathOption('git', 'projects_list', doc='Path to a gitweb-formatted projects.list')
+    projects_base = PathOption('git', 'projects_base', doc='Path to the base of your git projects')
+    projects_url = Option('git', 'projects_url', doc='Template for project URLs. %s will be replaced with the repo name')
 
     def get_repositories(self):
         if not self.projects_list:

--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -630,9 +630,6 @@ class GitChangeset(Changeset):
 
         Changeset.__init__(self, repos, rev=sha, message=msg, author=user_, date=time_)
 
-    def __repr__(self):
-        return '<GitChangeset %s>'%(self.rev,)
-
     def get_properties(self):
         properties = {}
 


### PR DESCRIPTION
This patch adds an optional repo provider that understands gitweb's projects.list. This works well with gitolite which can autogenerate that file. Also fix an error on empty repos.
