### PR TITLE
Better suggestion for wrong git_dir

### DIFF
--- a/tracext/git/PyGIT.py
+++ b/tracext/git/PyGIT.py
@@ -245,7 +245,7 @@ class Storage(object):
             self.logger.error("GIT control files missing in '%s'" % git_dir)
             if os.path.exists(__git_file_path('.git')):
                 self.logger.error("entry '.git' found in '%s'"
-                                  " -- maybe use that folder instead..." % git_dir)
+                                  " -- maybe use %s instead..." % os.path.join(git_dir, '.git'))
             raise GitError("GIT control files not found, maybe wrong directory?")
 
         self.logger.debug("PyGIT.Storage instance %d constructed" % id(self))


### PR DESCRIPTION
Refs #7381. If git_dir points to a cloned repo instead of a control dir, don't show an error that sounds like a suggestion to replace the dir with the same dir.

The current error is confusing because "that folder" is ambiguos:

```
2011-06-16 22:21:14,935 Trac[PyGIT] ERROR: GIT control files missing in '/var/lib/git/Repo'
2011-06-16 22:21:14,935 Trac[PyGIT] ERROR: entry '.git' found in '/var/lib/git/Repo' -- maybe use that folder instead...
```
