### PR TITLE
Unpacking "git --version" can throw a ValueError

### DIFF
--- a/tracext/git/PyGIT.py
+++ b/tracext/git/PyGIT.py
@@ -181,7 +181,7 @@ class Storage(object):
         try:
             g = GitCore(git_bin=git_bin)
             [v] = g.version().splitlines()
-            _, _, version = v.strip().split()
+            version = v.strip().split()[2]
             # 'version' has usually at least 3 numeric version components, e.g.::
             #  1.5.4.2
             #  1.5.4.3.230.g2db511


### PR DESCRIPTION
git --version can return a 4-part message like this:
  git version 1.2.3.4 (Apple Git-26)

This breaks the unpacking. It is more reliable to assume that the version part is the 3rd group than assuming that there are exactly 3 groups and the version is the 3rd group.
