### PR TITLE
Applied patch from http://trac-hacks.org/ticket/3104 to trac-0.11 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='hvr@gnu.org',
     keywords='trac scm plugin git',
     url="http://trac-hacks.org/wiki/GitPlugin",
-    version='0.11.0.2',
+    version='0.11.0.3',
     license="GPL",
     long_description="""
     This Trac 0.11 plugin provides support for the GIT SCM.

--- a/tracext/git/git_fs.py
+++ b/tracext/git/git_fs.py
@@ -301,6 +301,8 @@ class GitNode(Node):
 
                         if k=='tree':
                                 pass
+                        elif k=='commit':
+                                pass
                         elif k=='blob':
                                 kind = Node.FILE
                         else:


### PR DESCRIPTION
This is the submodules workaround that was first created 7 years ago in http://trac-hacks.org/ticket/3104. This is fixed for Trac-0.12 and Trac 1.0 but not Trac 0.11. While I recognize that users are encouraged to upgrade, this fix is offered for those who are not able to for whatever reason.
